### PR TITLE
Add professor model

### DIFF
--- a/app/Http/Controllers/CourseController.php
+++ b/app/Http/Controllers/CourseController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Http\Requests\StoreUpdateCourseRequest;
 use App\Models\Course;
+use App\Models\Professor;
 use App\Models\User;
 use Illuminate\Http\Request;
 
@@ -47,8 +48,9 @@ class CourseController extends Controller
         $pageName = "Create New Course ";
         $course = new Course();
         $courses = Course::all();
+        $professors = Professor::all();
 
-        return view('courses.create', compact('course', 'courses', 'pageName'));
+        return view('courses.create', compact('course', 'courses', 'professors', 'pageName'));
     }
 
     /**
@@ -96,8 +98,9 @@ class CourseController extends Controller
     {
         $pageName = "Edit " . $course->title;
         $courses = Course::all();
+        $professors = Professor::all();
 
-        return view('courses.edit', compact('course', 'courses', 'pageName'));
+        return view('courses.edit', compact('course', 'courses', 'professors', 'pageName'));
     }
 
     /**
@@ -110,6 +113,7 @@ class CourseController extends Controller
     {
         $course->update($request->all());
         $course->semesters()->sync($request->input('semester'));
+        $course->professors()->sync($request->input('professors'));
 
         return back()->with('status', 'Course Successfully Updated!');
     }

--- a/app/Http/Controllers/CourseController.php
+++ b/app/Http/Controllers/CourseController.php
@@ -63,6 +63,7 @@ class CourseController extends Controller
     {
         $course = Course::create($request->all());
         $course->semesters()->sync($request->input('semester'));
+        $course->professors()->sync($request->input('professors'));
 
         return redirect()->route('courses.index')->with('status', $course->title . ' Successfully Created!');
     }

--- a/app/Http/Controllers/ProfessorController.php
+++ b/app/Http/Controllers/ProfessorController.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Professor;
+use Illuminate\Http\Request;
+
+class ProfessorController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+    {
+        //
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function create()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  \App\Models\Professor  $professor
+     * @return \Illuminate\Http\Response
+     */
+    public function show(Professor $professor)
+    {
+        //
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     *
+     * @param  \App\Models\Professor  $professor
+     * @return \Illuminate\Http\Response
+     */
+    public function edit(Professor $professor)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \App\Models\Professor  $professor
+     * @return \Illuminate\Http\Response
+     */
+    public function update(Request $request, Professor $professor)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  \App\Models\Professor  $professor
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy(Professor $professor)
+    {
+        //
+    }
+}

--- a/app/Http/Requests/StoreUpdateCourseRequest.php
+++ b/app/Http/Requests/StoreUpdateCourseRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests;
 
 use App\Models\Course;
+use App\Models\Professor;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Str;
 use Illuminate\Validation\Rule;
@@ -57,6 +58,10 @@ class StoreUpdateCourseRequest extends FormRequest
                 'nullable',
                 Rule::in(Course::getCourseIDs()),
             ],
+            'professors.*' => [
+                'nullable',
+                Rule::in(Professor::getProfessorIDs()),
+            ],
         ];
     }
 
@@ -76,6 +81,12 @@ class StoreUpdateCourseRequest extends FormRequest
         if ($this->missing('concurrents')) {
             $this->merge([
                 'concurrents' => null
+            ]);
+        }
+
+        if ($this->missing('professors')) {
+            $this->merge([
+                'professors' => null
             ]);
         }
 

--- a/app/Models/Course.php
+++ b/app/Models/Course.php
@@ -44,6 +44,11 @@ class Course extends Model
         return $this->belongsToMany(User::class);
     }
 
+    public function professors()
+    {
+        return $this->belongsToMany(Professor::class);
+    }
+
     /**
      * Helpers
      */

--- a/app/Models/Course.php
+++ b/app/Models/Course.php
@@ -18,6 +18,13 @@ class Course extends Model
     protected $fillable = ["title", "description", "credits", "type", "abbreviation", 'prerequisites', 'concurrents',
                             'prerequisites_for_count', 'semester_specific'];
 
+    /**
+     * The relationships that should always be loaded.
+     *
+     * @var array
+     */
+    protected $with = ['professors'];
+
 
     /**
      * The attributes that should be cast to native types.

--- a/app/Models/Professor.php
+++ b/app/Models/Professor.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Professor extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['name'];
+
+    /**
+     * Relationships
+     */
+
+    public function courses()
+    {
+        return $this->belongsToMany(Course::class);
+    }
+
+}

--- a/app/Models/Professor.php
+++ b/app/Models/Professor.php
@@ -20,4 +20,13 @@ class Professor extends Model
         return $this->belongsToMany(Course::class);
     }
 
+    /**
+     * Helpers
+     */
+    public static function getProfessorIDs()
+    {
+        return Professor::all()->pluck('id')->toArray();
+    }
+
+
 }

--- a/database/migrations/2021_08_20_123940_create_professors_table.php
+++ b/database/migrations/2021_08_20_123940_create_professors_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateProfessorsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('professors', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('professors');
+    }
+}

--- a/database/migrations/2021_08_20_125737_create_course_professor_table.php
+++ b/database/migrations/2021_08_20_125737_create_course_professor_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateCourseProfessorTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('course_professor', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('course_id')->references('id')->on('courses')->onDelete('cascade');
+            $table->foreignId('professor_id')->references('id')->on('professors')->onDelete('cascade');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('course_professor', function (Blueprint $table) {
+            //
+        });
+    }
+}

--- a/database/migrations/2021_08_20_125737_create_course_professor_table.php
+++ b/database/migrations/2021_08_20_125737_create_course_professor_table.php
@@ -13,7 +13,7 @@ class CreateCourseProfessorTable extends Migration
      */
     public function up()
     {
-        Schema::table('course_professor', function (Blueprint $table) {
+        Schema::create('course_professor', function (Blueprint $table) {
             $table->id();
             $table->foreignId('course_id')->references('id')->on('courses')->onDelete('cascade');
             $table->foreignId('professor_id')->references('id')->on('professors')->onDelete('cascade');
@@ -28,8 +28,6 @@ class CreateCourseProfessorTable extends Migration
      */
     public function down()
     {
-        Schema::table('course_professor', function (Blueprint $table) {
-            //
-        });
+        Schema::dropIfExists('course_professor');
     }
 }

--- a/database/seeders/CourseProfessorSeeder.php
+++ b/database/seeders/CourseProfessorSeeder.php
@@ -1,0 +1,192 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Course;
+use App\Models\Professor;
+use Illuminate\Database\Seeder;
+
+class CourseProfessorSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        foreach (Course::all() as $course) {
+
+            if ($course->abbreviation == "ENGL 15") {
+                $profs = Professor::whereIn('name', ["Lauren Bello", "Andrew Erlandson", "Robert Reichle"])->pluck('id')->toArray();
+                $course->professors()->sync($profs);
+            }
+
+            if ($course->abbreviation == "MATH 22") {
+                $profs = Professor::whereIn('name', ["Neena Chopra"])->pluck('id')->toArray();
+                $course->professors()->sync($profs);
+            }
+
+            if ($course->abbreviation == "MATH 26") {
+                $profs = Professor::whereIn('name', ["Neena Chopra", "Steven Hair"])->pluck('id')->toArray();
+                $course->professors()->sync($profs);
+            }
+
+            if ($course->abbreviation == "EE 211") {
+                $profs = Professor::whereIn('name', ["Thomas Hemminger"])->pluck('id')->toArray();
+                $course->professors()->sync($profs);
+            }
+
+            if ($course->abbreviation == "CHEM 110") {
+                $profs = Professor::whereIn('name', ["Joseph Houck"])->pluck('id')->toArray();
+                $course->professors()->sync($profs);
+            }
+
+            if ($course->abbreviation == "CHEM 111") {
+                $profs = Professor::whereIn('name', ["Joseph Houck"])->pluck('id')->toArray();
+                $course->professors()->sync($profs);
+            }
+
+            if ($course->abbreviation == "CMPEN 270") {
+                $profs = Professor::whereIn('name', ["Eugene Walters"])->pluck('id')->toArray();
+                $course->professors()->sync($profs);
+            }
+
+            if ($course->abbreviation == "CMPEN 351") {
+                $profs = Professor::whereIn('name', ["Jalaa Hoblos"])->pluck('id')->toArray();
+                $course->professors()->sync($profs);
+            }
+
+            if ($course->abbreviation == "CMPEN 441") {
+                $profs = Professor::whereIn('name', ["Ahmed Sammoud"])->pluck('id')->toArray();
+                $course->professors()->sync($profs);
+            }
+
+            if ($course->abbreviation == "CMPEN 461") {
+                $profs = Professor::whereIn('name', ["Naseem Ibrahim"])->pluck('id')->toArray();
+                $course->professors()->sync($profs);
+            }
+
+            if ($course->abbreviation == "CMPSC 121") {
+                $profs = Professor::whereIn('name', ["Patrick Byrnes", "Barry Brinkman"])->pluck('id')->toArray();
+                $course->professors()->sync($profs);
+            }
+
+            if ($course->abbreviation == "CMPSC 122") {
+                $profs = Professor::whereIn('name', ["Meng Su", "Jalaa Hoblos"])->pluck('id')->toArray();
+                $course->professors()->sync($profs);
+            }
+
+            if ($course->abbreviation == "CMPSC 360") {
+                $profs = Professor::whereIn('name', ["Meng Su"])->pluck('id')->toArray();
+                $course->professors()->sync($profs);
+            }
+
+            if ($course->abbreviation == "CMPSC 431W") {
+                $profs = Professor::whereIn('name', ["Barry Brinkman"])->pluck('id')->toArray();
+                $course->professors()->sync($profs);
+            }
+
+            if ($course->abbreviation == "CMPSC 461") {
+                $profs = Professor::whereIn('name', ["Jalaa Hoblos"])->pluck('id')->toArray();
+                $course->professors()->sync($profs);
+            }
+
+            if ($course->abbreviation == "CMPSC 465") {
+                $profs = Professor::whereIn('name', ["Zhifeng Xiao"])->pluck('id')->toArray();
+                $course->professors()->sync($profs);
+            }
+
+            if ($course->abbreviation == "ENGL 202C") {
+                $profs = Professor::whereIn('name', ["Rose Bohn", "Dillon Rockrohr", "Kayla Huxford"])->pluck('id')->toArray();
+                $course->professors()->sync($profs);
+            }
+
+            if ($course->abbreviation == "MATH 140") {
+                $profs = Professor::whereIn('name', ["Kasha Przybyla"])->pluck('id')->toArray();
+                $course->professors()->sync($profs);
+            }
+
+            if ($course->abbreviation == "MATH 141") {
+                $profs = Professor::whereIn('name', ["Kasha Przybyla", "Seunghoon Bang"])->pluck('id')->toArray();
+                $course->professors()->sync($profs);
+            }
+
+            if ($course->abbreviation == "MATH 220") {
+                $profs = Professor::whereIn('name', ["Javed Siddique"])->pluck('id')->toArray();
+                $course->professors()->sync($profs);
+            }
+
+            if ($course->abbreviation == "MATH 250") {
+                $profs = Professor::whereIn('name', ["Nestor Handzy"])->pluck('id')->toArray();
+                $course->professors()->sync($profs);
+            }
+
+            if ($course->abbreviation == "MGMT 301") {
+                $profs = Professor::whereIn('name', ["Ron Johnson"])->pluck('id')->toArray();
+                $course->professors()->sync($profs);
+            }
+
+            if ($course->abbreviation == "PHYS 211") {
+                $profs = Professor::whereIn('name', ["Louis Leblond"])->pluck('id')->toArray();
+                $course->professors()->sync($profs);
+            }
+
+            if ($course->abbreviation == "PHYS 212") {
+                $profs = Professor::whereIn('name', ["Louis Leblond"])->pluck('id')->toArray();
+                $course->professors()->sync($profs);
+            }
+
+            if ($course->abbreviation == "STAT 318") {
+                $profs = Professor::whereIn('name', ["Zachariah Riel"])->pluck('id')->toArray();
+                $course->professors()->sync($profs);
+            }
+
+            if ($course->abbreviation == "SWENG 311") {
+                $profs = Professor::whereIn('name', ["Thomas Rossi"])->pluck('id')->toArray();
+                $course->professors()->sync($profs);
+            }
+
+            if ($course->abbreviation == "SWENG 411") {
+                $profs = Professor::whereIn('name', ["Adam Bondi"])->pluck('id')->toArray();
+                $course->professors()->sync($profs);
+            }
+
+            if ($course->abbreviation == "SWENG 421") {
+                $profs = Professor::whereIn('name', ["Wen-Li Wang"])->pluck('id')->toArray();
+                $course->professors()->sync($profs);
+            }
+
+            if ($course->abbreviation == "SWENG 431") {
+                $profs = Professor::whereIn('name', ["Barry Brinkman"])->pluck('id')->toArray();
+                $course->professors()->sync($profs);
+            }
+
+            if ($course->abbreviation == "SWENG 452") {
+                $profs = Professor::whereIn('name', ["Chen Cao"])->pluck('id')->toArray();
+                $course->professors()->sync($profs);
+            }
+
+            if ($course->abbreviation == "SWENG 480") {
+                $profs = Professor::whereIn('name', ["Naseem Ibrahim"])->pluck('id')->toArray();
+                $course->professors()->sync($profs);
+            }
+
+            if ($course->abbreviation == "SWENG 481") {
+                $profs = Professor::whereIn('name', ["Naseem Ibrahim"])->pluck('id')->toArray();
+                $course->professors()->sync($profs);
+            }
+
+            if ($course->abbreviation == "ECON 102") {
+                $profs = Professor::whereIn('name', ["Murat Inan"])->pluck('id')->toArray();
+                $course->professors()->sync($profs);
+            }
+
+            if ($course->abbreviation == "ECON 104") {
+                $profs = Professor::whereIn('name', ["Kapilan Mahalingam"])->pluck('id')->toArray();
+                $course->professors()->sync($profs);
+            }
+
+        }
+    }
+}

--- a/database/seeders/ProfessorSeeder.php
+++ b/database/seeders/ProfessorSeeder.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class ProfessorSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        foreach ($this->getProffesorData() as $professor) {
+            DB::table('professors')->insert([
+                'name' => $professor
+            ]);
+        }
+    }
+
+    private function getProffesorData()
+    {
+        return [
+            "Lauren Bello", "Andrew Erlandson", "Robert Reichle", "Neena Chopra", "Steven Hair", "Thomas Hemminger",
+            "Joseph Houck", "Eugene Walters", "Jalaa Hoblos", "Ahmed Sammoud", "Naseem Ibrahim", "Patrick Byrnes",
+            "Barry Brinkman", "Meng Su", "Zhifeng Xiao", "Rose Bohn", "Dillon Rockrohr", "Kayla Huxford",
+            "Kasha Przybyla", "Seunghoon Bang", "Javed Siddique", "Nestor Handzy", "Ron Johnson", "Louis Leblond",
+            "Zachariah Riel", "Thomas Rossi", "Adam Bondi", "Wen-Li Wang", "Chen Cao", "Murat Inan",
+            "Kapilan Mahalingam",
+        ];
+    }
+}

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -2553,6 +2553,27 @@ function CourseInspector(props) {
       }, "None");
     }
   };
+  /**
+   * Builds the jsx for each enabled course list item
+   * @param {Course} props
+   * @returns
+   */
+
+
+  var professors = function professors(props) {
+    if (props.selectedCourse && props.selectedCourse.professors.length > 0) {
+      return props.selectedCourse.professors.map(function (prof, key) {
+        return /*#__PURE__*/react__WEBPACK_IMPORTED_MODULE_0__.createElement("div", {
+          key: key,
+          className: "related-course-row text-gray-700"
+        }, prof.name);
+      });
+    } else {
+      return /*#__PURE__*/react__WEBPACK_IMPORTED_MODULE_0__.createElement("div", {
+        className: "related-course-row text-gray-700"
+      }, "Unkown");
+    }
+  };
 
   return /*#__PURE__*/react__WEBPACK_IMPORTED_MODULE_0__.createElement("div", {
     className: "left"
@@ -2598,7 +2619,13 @@ function CourseInspector(props) {
     className: "inspector-data-label text-gray-500"
   }, "Opens Courses:"), /*#__PURE__*/react__WEBPACK_IMPORTED_MODULE_0__.createElement("div", {
     id: "inspector-related-course"
-  }, openItems(props))))));
+  }, openItems(props))), /*#__PURE__*/react__WEBPACK_IMPORTED_MODULE_0__.createElement("div", {
+    className: "related-course-wrapper"
+  }, /*#__PURE__*/react__WEBPACK_IMPORTED_MODULE_0__.createElement("div", {
+    className: "inspector-data-label text-gray-500"
+  }, "Professors:"), /*#__PURE__*/react__WEBPACK_IMPORTED_MODULE_0__.createElement("div", {
+    id: "inspector-related-course"
+  }, professors(props))))));
 }
 
 /* harmony default export */ const __WEBPACK_DEFAULT_EXPORT__ = (CourseInspector);

--- a/resources/js/components/CourseInspector.js
+++ b/resources/js/components/CourseInspector.js
@@ -88,6 +88,32 @@ function CourseInspector(props) {
         }
     };
 
+    /**
+     * Builds the jsx for each enabled course list item
+     * @param {Course} props
+     * @returns
+     */
+    const professors = (props) => {
+        if (
+            props.selectedCourse &&
+            props.selectedCourse.professors.length > 0
+        ) {
+            return props.selectedCourse.professors.map((prof, key) => {
+
+                return (
+                    <div
+                        key={key}
+                        className="related-course-row text-gray-700"
+                    >
+                        {prof.name}
+                    </div>
+                );
+            });
+        } else {
+            return <div className="related-course-row text-gray-700">Unkown</div>
+        }
+    };
+
     return (
         <div className="left">
             <div id="inspector-selected-course">
@@ -143,6 +169,14 @@ function CourseInspector(props) {
                         </div>
                         <div id="inspector-related-course">
                             {openItems(props)}
+                        </div>
+                    </div>
+                    <div className="related-course-wrapper">
+                        <div className="inspector-data-label text-gray-500">
+                            Professors:
+                        </div>
+                        <div id="inspector-related-course">
+                            {professors(props)}
                         </div>
                     </div>
                 </div>

--- a/resources/views/courses/partials/course-form.blade.php
+++ b/resources/views/courses/partials/course-form.blade.php
@@ -51,6 +51,17 @@
         </select>
     </div>
     <div class="w-full md:w-2/5 px-3 mb-6 md:mb-0">
+        <label class="block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2" for="grid-prerequisites">
+            Professors
+        </label>
+        <select name="professors[]" multiple class="block appearance-none w-full bg-gray-200 border border-gray-200 text-gray-700 py-3 px-4 pr-8 rounded leading-tight focus:outline-none focus:bg-white focus:border-gray-500" id="grid-prerequisites">
+            <option></option>
+            @foreach($professors as $professor)
+                <option @if(in_array($professor->id, $course->professors->pluck('id')->toArray() ?? [])) selected @endif value="{{$professor->id}}">{{$professor->name}}</option>
+            @endforeach
+        </select>
+    </div>
+    <div class="w-full md:w-2/5 px-3 mb-6 md:mb-0">
         <label class="block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2" for="grid-concurrents">
             Concurrents
         </label>

--- a/resources/views/courses/show.blade.php
+++ b/resources/views/courses/show.blade.php
@@ -20,6 +20,20 @@
             @endforeach
         </p>
 
+        <p><strong>Professor(s)</strong>:
+            @if ($course->professors->isNotEmpty())
+                @foreach($course->professors as $professor)
+                    @if (! $loop->last)
+                        {{$professor->name}},
+                    @else
+                        {{$professor->name}}
+                    @endif
+                @endforeach
+            @else
+                Unknown
+            @endif
+        </p>
+
         <h4><strong>Prerequisites </strong></h4>
         @if(! $course->prerequisites)
             None


### PR DESCRIPTION
### Purpose
This PR adds the `Professor` model to the app. At the moment, "Professors" can be associated with a course. 

### Passing Test 
```
   PASS  Tests\Feature\CourseRecommendationsTest
  ✓ correct courses are not recommended without entering the number of courses
  ✓ correct courses are recommended 1
  ✓ correct courses are recommended 2
  ✓ correct courses are recommended 3
  ✓ correct courses are recommended 4
  ✓ correct courses are recommended 5
  ✓ correct courses are recommended 6
  ✓ correct courses are recommended 7
  ✓ correct courses are recommended 8
  ✓ correct courses are recommended 9

   PASS  Tests\Feature\CourseTest
  ✓ auth user can visit courses index
  ✓ auth user sees correct courses on courses index
  ✓ guest can not visit courses index
  ✓ dev auth user can visit create course
  ✓ non dev auth user can not visit create course
  ✓ guest can not visit create course
  ✓ dev auth user can visit edit course
  ✓ non dev auth user can not visit edit course
  ✓ guest can not visit edit course
  ✓ dev auth user can create a course
  ✓ dev auth user can create a course with prerequisites
  ✓ dev auth user can create a course with concurrents
  ✓ dev auth user can create a course with prerequisites and concurrents
  ✓ dev auth user can not create a course with a course title already taken
  ✓ dev auth user can not create a course with a course abbreviation already taken
  ✓ dev auth user can not create a course with no description
  ✓ dev auth user can not create a course with invalid number of credits
  ✓ dev auth user can not create a course with invalid semester choice
  ✓ dev auth user can not create a course with invalid concurrents choice
  ✓ dev auth user can not create a course with invalid prerequisites choice
  ✓ dev auth user can not create a course with invalid professor choice
  ✓ regular auth user can not create a course
  ✓ guest can not create a course
  ✓ dev auth user can update a course
  ✓ dev auth user can update a course with prerequisites
  ✓ dev auth user can update a course with concurrents and prerequisites
  ✓ dev auth user can update a course with concurrents prerequisites and professors
  ✓ dev auth user can not update a course with a course title already taken
  ✓ dev auth user can not update a course with a course abbreviation already taken
  ✓ dev auth user can not update a course with no description
  ✓ dev auth user can not update a course with invalid number of credits
  ✓ dev auth user can not update a course with invalid semester choice
  ✓ dev auth user can not update a course with invalid concurrents choice
  ✓ dev auth user can not update a course with invalid prerequisites choice
  ✓ dev auth user can not update a course with invalid professors choice
  ✓ regular auth user can not update a course
  ✓ guest can not update a course
  ✓ dev auth user can delete a course
  ✓ when dev auth user deletes a course it is removed as a prerequisite from other courses
  ✓ when dev auth user deletes a course it is removed from the course professor table
  ✓ regular auth user can not delete a course
  ✓ guest can not delete a course

   PASS  Tests\Feature\RegisterTest
  ✓ guest can register for the site
  ✓ guest can not register with out a penn state email address

   PASS  Tests\Feature\UsersIndexTest
  ✓ dev user can visit users index
  ✓ regular user can not visit users index
  ✓ guest can not visit users index

  Tests:  57 passed
  Time:   7.20s
```